### PR TITLE
Add configuration files to build and run tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Tests
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore: [ '**.md' ]
+  pull_request:
+    paths-ignore: [ '**.md' ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        build_type: [Debug, Release]
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: patch misc/conftest.cpp
+      run: git apply 0001-conftest.cpp.patch
+    - name: cmake
+      run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+    - name: build
+      run: cmake --build build --config ${{ matrix.build_type }}
+    - name: test
+      run: ctest --output-on-failure --test-dir build -C ${{ matrix.build_type }}

--- a/0001-conftest.cpp.patch
+++ b/0001-conftest.cpp.patch
@@ -1,0 +1,7 @@
+--- a/srell-src/misc/conftest.cpp
++++ b/srell-src/misc/conftest.cpp
+@@ -883,3 +883,3 @@ int main(const int argc, const char *const argv[])
+
+-	return 0;
++	return num_of_tests_passed == num_of_tests ? 0 : 1;
+ }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.7...3.13)
+
+# Require C++11
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Project settings
+project(test-srell LANGUAGES CXX)
+
+add_executable(conftest srell-src/misc/conftest.cpp)
+
+# Testing
+enable_testing()
+
+foreach(test_arg utf8 utf16 utf32 utf8c)
+  add_test(NAME conftest-${test_arg}
+    COMMAND ${CMAKE_CURRENT_BINARY_DIR}/conftest ${test_arg})
+endforeach()


### PR DESCRIPTION
Also add the `0001-conftest.cpp.patch` file. This patch ensures that `misc/conftest.cpp` only returns `0` if all tests pass.