### PR TITLE
Do not patch misc/conftest.cpp starting with SRELL 4.090

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v5
-    - name: patch misc/conftest.cpp
-      run: git apply 0001-conftest.cpp.patch
     - name: cmake
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
     - name: build

--- a/0001-conftest.cpp.patch
+++ b/0001-conftest.cpp.patch
@@ -1,7 +1,0 @@
---- a/srell-src/misc/conftest.cpp
-+++ b/srell-src/misc/conftest.cpp
-@@ -883,3 +883,3 @@ int main(const int argc, const char *const argv[])
-
--	return 0;
-+	return num_of_tests_passed == num_of_tests ? 0 : 1;
- }


### PR DESCRIPTION
In SRELL 4.090, the misc/conftest.cpp program returns a non-zero exit code when not all tests pass.